### PR TITLE
The dependencies cannot be optional because they are used in __init__

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,11 +11,15 @@ authors = [
 ]
 
 dependencies = [
-    "torch",
-    "torchvision",
-    "pathlib",
-    "pandas",
-    "numpy"
+  "torch",
+  "torchvision",
+  "pathlib",
+  "pandas",
+  "numpy",
+  "datasets",
+  "kagglehub",
+  "zenodo-client",
+  "synapseclient",
 ]
 
 [project.optional-dependencies]
@@ -26,23 +30,6 @@ dev = [
   "mypy",
   "pandas-stubs",
 ]
-
-huggingface = [
-    "datasets",
-]
-
-kaggle = [
-    "kagglehub",
-]
-
-zenodo = [
-  "zenodo-client",
-]
-
-synapse = [
-  "synapseclient",
-]
-
 
 [project.urls]
 Homepage = "https://github.com/goldener-data/any-gold"

--- a/uv.lock
+++ b/uv.lock
@@ -128,11 +128,15 @@ name = "any-gold"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "datasets" },
+    { name = "kagglehub" },
     { name = "numpy" },
     { name = "pandas" },
     { name = "pathlib" },
+    { name = "synapseclient" },
     { name = "torch" },
     { name = "torchvision" },
+    { name = "zenodo-client" },
 ]
 
 [package.optional-dependencies]
@@ -143,23 +147,11 @@ dev = [
     { name = "pytest" },
     { name = "ruff" },
 ]
-huggingface = [
-    { name = "datasets" },
-]
-kaggle = [
-    { name = "kagglehub" },
-]
-synapse = [
-    { name = "synapseclient" },
-]
-zenodo = [
-    { name = "zenodo-client" },
-]
 
 [package.metadata]
 requires-dist = [
-    { name = "datasets", marker = "extra == 'huggingface'" },
-    { name = "kagglehub", marker = "extra == 'kaggle'" },
+    { name = "datasets" },
+    { name = "kagglehub" },
     { name = "mypy", marker = "extra == 'dev'" },
     { name = "numpy" },
     { name = "pandas" },
@@ -168,12 +160,12 @@ requires-dist = [
     { name = "pre-commit", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "ruff", marker = "extra == 'dev'" },
-    { name = "synapseclient", marker = "extra == 'synapse'" },
+    { name = "synapseclient" },
     { name = "torch" },
     { name = "torchvision" },
-    { name = "zenodo-client", marker = "extra == 'zenodo'" },
+    { name = "zenodo-client" },
 ]
-provides-extras = ["dev", "huggingface", "kaggle", "zenodo", "synapse"]
+provides-extras = ["dev"]
 
 [[package]]
 name = "anyio"


### PR DESCRIPTION
## Description

no dataset addition

This pull request updates the `pyproject.toml` file to consolidate dependencies and simplify the structure. It moves several optional dependencies into the main `dependencies` list and removes redundant optional dependency groups.

Dependency updates:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L18-R22): Added `datasets`, `kagglehub`, `zenodo-client`, and `synapseclient` to the main `dependencies` list. These were previously part of separate optional dependency groups.

Simplification of optional dependencies:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L30-L46): Removed optional dependency groups (`huggingface`, `kaggle`, `zenodo`, `synapse`) and their associated entries, as these dependencies are now included in the main `dependencies` list.


