### PR TITLE
use uv run to launch mypy during pre commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,8 +16,11 @@ repos:
         - --exit-non-zero-on-fix
     -   id: ruff-format
 
--   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.8.0
-    hooks:
-    -   id: mypy
-        exclude: ^(docs/|examples/)
+- repo: local
+  hooks:
+    - id: local-mypy
+      name: mypy
+      entry: "uv run mypy"
+      language: python
+      types: [python]
+      require_serial: true


### PR DESCRIPTION
## Description

no dataset added

This pull request updates the `.pre-commit-config.yaml` file to replace the external `mypy` repository with a local configuration for running `mypy`. The change ensures better control over the `mypy` execution process and aligns it with local development needs.

Configuration updates:

* [`.pre-commit-config.yaml`](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L19-R26): Replaced the external `mypy` repository (`https://github.com/pre-commit/mirrors-mypy`) with a local `mypy` configuration. The new configuration uses the `uv run mypy` entry, specifies Python as the language, and requires serial execution.



