### PR TITLE
Mask right size

### DIFF
--- a/any_gold/image/mvtec_ad.py
+++ b/any_gold/image/mvtec_ad.py
@@ -109,8 +109,8 @@ class MVTecADDataset(AnyVisionSegmentationDataset, HuggingFaceDataset):
         mask = TvMask(
             sample["mask_path"]
             if sample["mask_path"] is not None
-            else torch.zeros((1, 1, *image.shape[-2:]), dtype=torch.uint8)
-        )
+            else torch.zeros((1, *image.shape[-2:]), dtype=torch.uint8)
+        ).unsqueeze(0)
 
         return MVTecADOutput(
             image=image,

--- a/any_gold/image/mvtec_ad.py
+++ b/any_gold/image/mvtec_ad.py
@@ -104,13 +104,13 @@ class MVTecADDataset(AnyVisionSegmentationDataset, HuggingFaceDataset):
         """
         sample = self.samples[index]
 
-        image = TvImage(sample["image_path"].unsqueeze(0))
+        image = TvImage(sample["image_path"])
 
         mask = TvMask(
             sample["mask_path"]
             if sample["mask_path"] is not None
             else torch.zeros((1, *image.shape[-2:]), dtype=torch.uint8)
-        ).unsqueeze(0)
+        )
 
         return MVTecADOutput(
             image=image,

--- a/any_gold/image/plantseg.py
+++ b/any_gold/image/plantseg.py
@@ -149,5 +149,9 @@ class PlantSeg(AnyVisionSegmentationDataset, ZenodoZipBase):
         mask = load_torchvision_mask(mask_path)
 
         return PlantSegOutput(
-            image=image, mask=mask, plant=plant, disease=disease, index=index
+            index=index,
+            image=image,
+            mask=mask,
+            plant=plant,
+            disease=disease,
         )

--- a/any_gold/utils/dataset.py
+++ b/any_gold/utils/dataset.py
@@ -64,6 +64,8 @@ class AnyVisionSegmentationOutput(AnyOutput):
 class AnyVisionSegmentationDataset(VisionDataset, AnyDataset):
     """Base class for any vision dataset.
 
+    The image and mask are expected to be in the torchvision format with a shape C, H, W for images and masks.
+
     Attributes:
         root: The root directory where the dataset is stored.
         transform: A transform to apply to the images.

--- a/any_gold/utils/load.py
+++ b/any_gold/utils/load.py
@@ -5,12 +5,12 @@ from PIL import Image as PILImage
 
 
 def load_torchvision_image(path: Path) -> TvImage:
-    """Load an image from a file path and convert it to a (1, 3, H, W) Torchvision Image tensor."""
+    """Load an image from a file path and convert it to a (3, H, W) Torchvision Image tensor."""
     pil_image = PILImage.open(path).convert("RGB")
-    return TvImage(pil_image).unsqueeze(0)
+    return TvImage(pil_image)
 
 
 def load_torchvision_mask(path: Path) -> TvMask:
-    """Load a mask from a file path and convert it to a (1, 1, H, W) Torchvision Mask tensor."""
+    """Load a mask from a file path and convert it to a (1, H, W) Torchvision Mask tensor."""
     pil_mask = PILImage.open(path).convert("L")
-    return TvMask(pil_mask).unsqueeze(0)
+    return TvMask(pil_mask)

--- a/tests/image/test_deepglobe.py
+++ b/tests/image/test_deepglobe.py
@@ -1,11 +1,13 @@
 import pytest
 
-from kagglehub import registry
 from pathlib import Path
 
+from kagglehub import registry
 from kagglehub.handle import DatasetHandle
 
-from any_gold.image.deepglobe import DeepGlobeRoadExtraction
+from torch.utils.data import RandomSampler, DataLoader
+
+from any_gold import DeepGlobeRoadExtraction
 from tests.conftest import TEST_DATASET_LOADING
 
 
@@ -31,10 +33,27 @@ class TestDeepGlobeRoadExtraction:
 
         assert len(dataset) == 6226, "Dataset length is not as expected"
 
-        image, mask, index = dataset[0]
-        assert index == 0, "Index is not as expected"
-        assert image.shape == (1, 3, 1024, 1024), "Image shape is not as expected"
-        assert mask.shape == (1, 1, 1024, 1024), "Mask shape is not as expected"
+        output = dataset[0]
+        assert output["index"] == 0, "Index is not as expected"
+        assert output["image"].shape == (
+            3,
+            1024,
+            1024,
+        ), "Image shape is not as expected"
+        assert output["mask"].shape == (1, 1024, 1024), "Mask shape is not as expected"
         assert dataset.get_image_path(0) == Path(
             "/storage/ml/deepglobe_road_extraction/train/839673_sat.jpg"
         ), "Image path is not as expected"
+
+        sampler = RandomSampler(dataset, replacement=False, num_samples=5)
+        dataloader = DataLoader(
+            dataset,
+            batch_size=5,
+            sampler=sampler,
+            num_workers=0,
+        )
+        for batch in dataloader:
+            (
+                batch["image"].shape == (5, 3, 1024, 1024),
+                "Batch image shape is not as expected",
+            )


### PR DESCRIPTION
## Description

Do not add any new datasets

This pull request introduces changes to standardize the data structure used across multiple datasets, refactors image and mask handling to simplify their shapes, and updates the test cases accordingly. The most important changes include transitioning to a consistent output format for datasets, modifying the shape of images and masks, and improving test coverage with additional checks and batching.

### Dataset Output Standardization:
* Updated `get_raw` methods in `any_gold/image/mvtec_ad.py` and `any_gold/image/plantseg.py` to ensure consistent ordering of attributes in dataset outputs. (`[[1]](diffhunk://#diff-ed17a09f8f52806b251bf8c7434346942c5bde778a6b4b8037747d20241b7c61L107-R112)`, `[[2]](diffhunk://#diff-6212d1bcd64724260bb69372ad84e2e8b64877440d5263bdfd13333f3eea327cL152-R156)`)
* Added documentation in `any_gold/utils/dataset.py` to specify the expected format for images and masks. (`[any_gold/utils/dataset.pyR67-R68](diffhunk://#diff-b94ce0db75cb0df5f0ad42b441beb092efad742c2f1f70a64c09ffb3b55f3d83R67-R68)`)

### Image and Mask Shape Refactor:
* Modified `load_torchvision_image` and `load_torchvision_mask` functions in `any_gold/utils/load.py` to simplify image and mask shapes by removing unnecessary dimensions. (`[any_gold/utils/load.pyL8-R16](diffhunk://#diff-1ee8b265b8e2f9724c859a9853a39a0dab132dde8382e4b9018e1edea052c773L8-R16)`)
* Adjusted dataset-specific methods and tests to reflect the new image and mask shapes. For example, images now follow `(3, H, W)` and masks follow `(1, H, W)`. (`[[1]](diffhunk://#diff-c32d0adfc4e7dea68d956f3ffc59f3540f77cc167b437910163e5993d16d8e3dL34-R59)`, `[[2]](diffhunk://#diff-fa9dc17ba5b585c55cf72c56f290eb989a0ba67c14f6cbf33426cd1fe7e0205dL39-R65)`, `[[3]](diffhunk://#diff-5dacc1773102e7c9587f1adb2ff61e32f7e238b8f584e52ba758644507932179L28-R52)`, `[[4]](diffhunk://#diff-65fc2302f618a6efdc25e8f32a689a4a89ed0f52d5849a5d1ac825ae2e815f5dR31-R57)`)

### Test Enhancements:
* Updated test cases for datasets (`test_deepglobe.py`, `test_kpi.py`, `test_mvtecad.py`, `test_plantseg.py`) to validate the new output format and shapes. (`[[1]](diffhunk://#diff-c32d0adfc4e7dea68d956f3ffc59f3540f77cc167b437910163e5993d16d8e3dL34-R59)`, `[[2]](diffhunk://#diff-fa9dc17ba5b585c55cf72c56f290eb989a0ba67c14f6cbf33426cd1fe7e0205dL39-R65)`, `[[3]](diffhunk://#diff-5dacc1773102e7c9587f1adb2ff61e32f7e238b8f584e52ba758644507932179L28-R52)`, `[[4]](diffhunk://#diff-65fc2302f618a6efdc25e8f32a689a4a89ed0f52d5849a5d1ac825ae2e815f5dR31-R57)`)
* Added batching and sampling logic in tests using `RandomSampler` and `DataLoader` to ensure compatibility with batch operations. (`[[1]](diffhunk://#diff-c32d0adfc4e7dea68d956f3ffc59f3540f77cc167b437910163e5993d16d8e3dL34-R59)`, `[[2]](diffhunk://#diff-fa9dc17ba5b585c55cf72c56f290eb989a0ba67c14f6cbf33426cd1fe7e0205dL39-R65)`, `[[3]](diffhunk://#diff-5dacc1773102e7c9587f1adb2ff61e32f7e238b8f584e52ba758644507932179L28-R52)`, `[[4]](diffhunk://#diff-65fc2302f618a6efdc25e8f32a689a4a89ed0f52d5849a5d1ac825ae2e815f5dR31-R57)`)


## Checklist

- [ ] Does your new dataset inherit from `AnyDataset`?
- [ ] Does your new dataset existence online have been tested? (please add a specific unit test for it)
- [ ] Does the loading of your new dataset work as expected? (please add a specific unit test protected by `TEST_DATASET_LOADING` for it)
- [ ] Has your new dataset added to the README.md file?
