### PR TITLE
Make the output of dataset getitem a typeddict

### DIFF
--- a/any_gold/image/deepglobe.py
+++ b/any_gold/image/deepglobe.py
@@ -2,7 +2,6 @@ import shutil
 from pathlib import Path
 from typing import Callable
 
-from torchvision.tv_tensors import Image as TvImage, Mask as TvMask
 
 from any_gold.utils.dataset import (
     AnyVisionSegmentationDataset,
@@ -15,11 +14,10 @@ from any_gold.utils.load import load_torchvision_image, load_torchvision_mask
 class DeepGlobeRoadExtractionOutput(AnyVisionSegmentationOutput):
     """Output class for DeepGlobe Road Extraction dataset.
 
-    It does not include more than the index, image, and mask already included in AnyVisionSegmentationOutput.
+    The label will always be `road`.
     """
 
-    def __init__(self, *, index: int, image: TvImage, mask: TvMask):
-        super().__init__(index=index, image=image, mask=mask)
+    pass
 
 
 class DeepGlobeRoadExtraction(AnyVisionSegmentationDataset, KaggleDataset):
@@ -117,4 +115,6 @@ class DeepGlobeRoadExtraction(AnyVisionSegmentationDataset, KaggleDataset):
         image = load_torchvision_image(image_path)
         mask = load_torchvision_mask(mask_path) if mask_path.exists() else None
 
-        return DeepGlobeRoadExtractionOutput(image=image, mask=mask, index=index)
+        return DeepGlobeRoadExtractionOutput(
+            image=image, mask=mask, index=index, label="road"
+        )

--- a/any_gold/image/kpi.py
+++ b/any_gold/image/kpi.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 from typing import Callable
 
-from torchvision.tv_tensors import Image as TvImage, Mask as TvMask
 
 from any_gold.utils.dataset import (
     AnyVisionSegmentationDataset,
@@ -14,11 +13,10 @@ from any_gold.utils.synapse import SynapseZipBase
 class KPITask1PatchLevelOutput(AnyVisionSegmentationOutput):
     """Output class for KPI Task 1 Patch Level dataset.
 
-    It extends the AnyVisionSegmentationOutput class to include disease information.
+    The label is the name of the disease.
     """
 
-    def __init__(self, *, index: int, image: TvImage, mask: TvMask, disease: str):
-        super().__init__(index=index, image=image, mask=mask, disease=disease)
+    pass
 
 
 class KPITask1PatchLevel(AnyVisionSegmentationDataset, SynapseZipBase):
@@ -120,5 +118,5 @@ class KPITask1PatchLevel(AnyVisionSegmentationDataset, SynapseZipBase):
         mask = load_torchvision_mask(mask_path)
 
         return KPITask1PatchLevelOutput(
-            image=image, mask=mask, disease=disease, index=index
+            image=image, mask=mask, label=disease, index=index
         )

--- a/any_gold/image/mvtec_ad.py
+++ b/any_gold/image/mvtec_ad.py
@@ -14,22 +14,13 @@ from any_gold.utils.hugging_face import HuggingFaceDataset
 class MVTecADOutput(AnyVisionSegmentationOutput):
     """Output class for MVTec Anomaly Detection dataset.
 
-    It extends the AnyVisionSegmentationOutput class to include label (either `good` or a defect type) and
+    It extends the AnyVisionSegmentationOutput class to include
     target (torch tensor indicating if the label is an anomaly or not).
+
+    The label is the type of defect (`good` in absence of defect).
     """
 
-    def __init__(
-        self,
-        *,
-        index: int,
-        image: TvImage,
-        mask: TvMask,
-        label: str,
-        target: torch.Tensor,
-    ):
-        super().__init__(
-            index=index, image=image, mask=mask, label=label, target=target
-        )
+    target: torch.Tensor
 
 
 class MVTecADDataset(AnyVisionSegmentationDataset, HuggingFaceDataset):

--- a/any_gold/image/plantseg.py
+++ b/any_gold/image/plantseg.py
@@ -2,7 +2,6 @@ from pathlib import Path
 from typing import Callable
 
 import pandas as pd
-from torchvision.tv_tensors import Image as TvImage, Mask as TvMask
 
 from any_gold.utils.dataset import (
     AnyVisionSegmentationOutput,
@@ -15,15 +14,11 @@ from any_gold.utils.zenodo import ZenodoZipBase
 class PlantSegOutput(AnyVisionSegmentationOutput):
     """Output class for PlantSeg dataset.
 
-    It extends the AnyVisionSegmentationOutput class to include plant species and disease information.
+    It extends the AnyVisionSegmentationOutput class to include plant species.
+    The label will be the disease on the plant.
     """
 
-    def __init__(
-        self, *, index: int, image: TvImage, mask: TvMask, plant: str, disease: str
-    ):
-        super().__init__(
-            index=index, image=image, mask=mask, plant=plant, disease=disease
-        )
+    plant: str
 
 
 class PlantSeg(AnyVisionSegmentationDataset, ZenodoZipBase):
@@ -153,5 +148,5 @@ class PlantSeg(AnyVisionSegmentationDataset, ZenodoZipBase):
             image=image,
             mask=mask,
             plant=plant,
-            disease=disease,
+            label=disease,
         )

--- a/any_gold/utils/dataset.py
+++ b/any_gold/utils/dataset.py
@@ -1,13 +1,13 @@
 from abc import abstractmethod
 from pathlib import Path
-from typing import Callable, OrderedDict, Any
+from typing import Callable, TypedDict
 
 from torch.utils.data import Dataset
 from torchvision.datasets import VisionDataset
 from torchvision.tv_tensors import Image as TvImage, Mask as TvMask
 
 
-class AnyOutput(OrderedDict):
+class AnyOutput(TypedDict):
     """Base class for any output from a dataset.
 
     It specifies the output format for any dataset. All any gold dataset is expected to return an instance of this class.
@@ -15,8 +15,7 @@ class AnyOutput(OrderedDict):
     other information such as image, annotation, etc...
     """
 
-    def __init__(self, *, index: int, **kwargs: Any):
-        super().__init__(index=index, **kwargs)
+    index: int
 
 
 class AnyDataset(Dataset):
@@ -57,8 +56,9 @@ class AnyVisionSegmentationOutput(AnyOutput):
     It extends the AnyOutput class to include image and mask attributes.
     """
 
-    def __init__(self, *, index: int, image: TvImage, mask: TvMask, **kwargs: Any):
-        super().__init__(index=index, image=image, mask=mask, **kwargs)
+    image: TvImage
+    mask: TvMask | None
+    label: str
 
 
 class AnyVisionSegmentationDataset(VisionDataset, AnyDataset):


### PR DESCRIPTION
## Description

do not add any new dataset

This pull request refactors the dataset output classes across multiple files in the `any_gold/image` module to simplify their structure and improve consistency. It replaces the `AnyOutput` class with a `TypedDict` and removes the explicit constructors from derived classes, relying on type annotations instead. Additionally, it standardizes the use of the `label` attribute for dataset-specific metadata.

### Refactoring and Type Standardization:

* [`any_gold/utils/dataset.py`](diffhunk://#diff-b94ce0db75cb0df5f0ad42b441beb092efad742c2f1f70a64c09ffb3b55f3d83L3-R18): Changed `AnyOutput` from an `OrderedDict` to a `TypedDict`, simplifying its structure and removing the constructor. Updated `AnyVisionSegmentationOutput` to include type annotations for `image`, `mask`, and `label`, replacing the constructor. [[1]](diffhunk://#diff-b94ce0db75cb0df5f0ad42b441beb092efad742c2f1f70a64c09ffb3b55f3d83L3-R18) [[2]](diffhunk://#diff-b94ce0db75cb0df5f0ad42b441beb092efad742c2f1f70a64c09ffb3b55f3d83L60-R61)

### Dataset-Specific Output Changes:

* [`any_gold/image/deepglobe.py`](diffhunk://#diff-ad50d1afc78121fab535b04916d69f1003483cd5d28766c2f8eadf1d891c6cedL18-R20): Simplified `DeepGlobeRoadExtractionOutput` by removing its constructor and explicitly defining the label as `"road"`. Updated `get_raw` to set the label attribute. [[1]](diffhunk://#diff-ad50d1afc78121fab535b04916d69f1003483cd5d28766c2f8eadf1d891c6cedL18-R20) [[2]](diffhunk://#diff-ad50d1afc78121fab535b04916d69f1003483cd5d28766c2f8eadf1d891c6cedL120-R120)
* [`any_gold/image/kpi.py`](diffhunk://#diff-81d0175d0e6fd802fd3337b8e3fbe4247648898c574a496f64e89fc4ae0607bbL17-R19): Removed the constructor from `KPITask1PatchLevelOutput` and standardized the `label` attribute to represent the disease name. Updated `get_raw` to set the label attribute. [[1]](diffhunk://#diff-81d0175d0e6fd802fd3337b8e3fbe4247648898c574a496f64e89fc4ae0607bbL17-R19) [[2]](diffhunk://#diff-81d0175d0e6fd802fd3337b8e3fbe4247648898c574a496f64e89fc4ae0607bbL123-R121)
* [`any_gold/image/mvtec_ad.py`](diffhunk://#diff-ed17a09f8f52806b251bf8c7434346942c5bde778a6b4b8037747d20241b7c61L17-R23): Refactored `MVTecADOutput` by removing its constructor and explicitly documenting the `label` attribute for defect types. Added type annotation for `target`.
* [`any_gold/image/plantseg.py`](diffhunk://#diff-6212d1bcd64724260bb69372ad84e2e8b64877440d5263bdfd13333f3eea327cL18-R21): Simplified `PlantSegOutput` by removing its constructor and using the `label` attribute for disease information. Updated `get_raw` to set the label attribute. [[1]](diffhunk://#diff-6212d1bcd64724260bb69372ad84e2e8b64877440d5263bdfd13333f3eea327cL18-R21) [[2]](diffhunk://#diff-6212d1bcd64724260bb69372ad84e2e8b64877440d5263bdfd13333f3eea327cL156-R151)

### Removal of Unused Imports:

* Removed unused imports of `Image` and `Mask` from `torchvision.tv_tensors` across all affected files (`deepglobe.py`, `kpi.py`, `plantseg.py`). [[1]](diffhunk://#diff-ad50d1afc78121fab535b04916d69f1003483cd5d28766c2f8eadf1d891c6cedL5) [[2]](diffhunk://#diff-81d0175d0e6fd802fd3337b8e3fbe4247648898c574a496f64e89fc4ae0607bbL4) [[3]](diffhunk://#diff-6212d1bcd64724260bb69372ad84e2e8b64877440d5263bdfd13333f3eea327cL5)

## Checklist

- [ ] Does your new dataset inherit from `AnyDataset`?
- [ ] Does your new dataset existence online have been tested? (please add a specific unit test for it)
- [ ] Does the loading of your new dataset work as expected? (please add a specific unit test protected by `TEST_DATASET_LOADING` for it)
- [ ] Has your new dataset added to the README.md file?
