### PR TITLE
Better mypy initialization and add AnyVisionSegmentationDataset to __init__.py

### DIFF
--- a/any_gold/__init__.py
+++ b/any_gold/__init__.py
@@ -1,10 +1,11 @@
-from .utils.dataset import AnyRawDataset
+from .utils.dataset import AnyRawDataset, AnyVisionSegmentationDataset
 from .image.plantseg import PlantSeg
 from .image.deepglobe import DeepGlobeRoadExtraction
 from .image.kpi import KPITask1PatchLevel
 from .image.mvtec_ad import MVTecADDataset
 
 __all__ = (
+    "AnyVisionSegmentationDataset",
     "AnyRawDataset",
     "PlantSeg",
     "DeepGlobeRoadExtraction",

--- a/mypy.ini
+++ b/mypy.ini
@@ -9,10 +9,10 @@ warn_unused_configs = true
 local_partial_types = true
 
 
-[mypy-gold_anomaly,gold_anomaly.*,]
+[mypy-any_gold,any_gold.*,]
 disallow_untyped_defs = true
 
-[mypy-tests.*,examples.*, tools.*]
+[mypy-tests.*]
 disallow_untyped_defs = false
 
 


### PR DESCRIPTION
## Description

do not include new dataset

This pull request introduces a new dataset class to the `any_gold` module and updates the `mypy.ini` configuration to reflect changes in naming conventions and simplify type-checking rules.

### Changes to the `any_gold` module:

* [`any_gold/__init__.py`](diffhunk://#diff-9e7cf5a25cfee786401093c920ac714bbfe081c3ccf374766f8da9d6a50fe2b8L1-R8): Added the `AnyVisionSegmentationDataset` class to the import list and the `__all__` tuple, making it available for external use.

### Updates to type-checking configuration:

* [`mypy.ini`](diffhunk://#diff-6f2d4ba9ca9a357d31014946667b7bed1bfdbc6d2530afc77778fa0a36bee457L12-R15): Renamed type-checking configuration sections from `gold_anomaly` to `any_gold` to match the updated module name and removed redundant sections for `tests`, `examples`, and `tools`.


## Checklist

- [ ] Does your new dataset inherit from `AnyDataset`?
- [ ] Does your new dataset existence online have been tested? (please add a specific unit test for it)
- [ ] Does the loading of your new dataset work as expected? (please add a specific unit test protected by `TEST_DATASET_LOADING` for it)
- [ ] Has your new dataset added to the README.md file?
