### PR TITLE
Make sure every dataset is working fine when no data is cached locally

### DIFF
--- a/any_gold/image/kpi.py
+++ b/any_gold/image/kpi.py
@@ -100,7 +100,7 @@ class KPITask1PatchLevel(AnyVisionSegmentationDataset, SynapseZipBase):
 
         self.samples: list[tuple[Path, str]] = [
             (image_path, class_dir.name)
-            for class_dir in (root / self._ENTITIES[self.split]["name"]).iterdir()
+            for class_dir in root.iterdir()
             for patch_dir in class_dir.iterdir()
             for image_path in (patch_dir / "img").glob("*.jpg")
         ]

--- a/any_gold/image/mvtec_ad.py
+++ b/any_gold/image/mvtec_ad.py
@@ -71,7 +71,6 @@ class MVTecADDataset(AnyVisionSegmentationDataset, HuggingFaceDataset):
 
         HuggingFaceDataset.__init__(
             self,
-            root=root,
             path=self._HUGGINGFACE_NAME,
             hf_split=f"{self.category}.{self.split}",
             override=override,

--- a/any_gold/utils/hugging_face.py
+++ b/any_gold/utils/hugging_face.py
@@ -1,8 +1,8 @@
 import os
 from functools import partial
-from pathlib import Path
 
 import datasets
+import huggingface_hub.utils
 from datasets import load_dataset, DownloadConfig
 from datasets.exceptions import DatasetNotFoundError
 from datasets import Dataset as HFDataset
@@ -32,13 +32,12 @@ class HuggingFaceDataset(AnyDataset):
 
     def __init__(
         self,
-        root: str | Path,
         path: str,
         hf_split: str | None = None,
         override: bool = False,
     ) -> None:
         super().__init__(
-            root=root,
+            root=huggingface_hub.constants.HUGGINGFACE_HUB_CACHE,
             override=override,
         )
 

--- a/any_gold/utils/kaggle.py
+++ b/any_gold/utils/kaggle.py
@@ -40,7 +40,7 @@ class KaggleDataset(AnyDataset):
         """download the data from Kaggle and initialize the elements of the dataset."""
 
     @abstractmethod
-    def _move_data_to_root(self, dataset_directory: Path) -> None:
+    def _move_data_to_root(self, kaggle_cache: Path) -> None:
         """Make the data available in the root directory.
 
         This method can be used to extract the data from an archive or to reorganise the data after downloading it.
@@ -48,13 +48,8 @@ class KaggleDataset(AnyDataset):
 
     def download(self) -> None:
         """Download the data from kaggle and store the dataset in the root folder."""
-
         logger.info(f"Downloading {self.handle} to kagglehub cache.")
         kaggle_cache = kagglehub.dataset_download(
-            self.handle,
+            self.handle, force_download=self.override
         )
-        if not self.root.exists():
-            self.root.mkdir(parents=True, exist_ok=True)
-
-        logger.info(f"Move {self.handle} from {kaggle_cache} to {self.root}")
         self._move_data_to_root(Path(kaggle_cache))


### PR DESCRIPTION
## Description

This pull request refactors dataset handling across several modules to improve code clarity, consistency, and functionality. Key changes include updating split handling, refining dataset initialization, and improving directory management for downloaded data.

### Updates to Dataset Split Handling:
* [`any_gold/image/deepglobe.py`](diffhunk://#diff-ad50d1afc78121fab535b04916d69f1003483cd5d28766c2f8eadf1d891c6cedR52-R56): Introduced `_SPLITS` dictionary for managing dataset splits (`train`, `val`, `test`) and updated validation logic to use this dictionary. [[1]](diffhunk://#diff-ad50d1afc78121fab535b04916d69f1003483cd5d28766c2f8eadf1d891c6cedR52-R56) [[2]](diffhunk://#diff-ad50d1afc78121fab535b04916d69f1003483cd5d28766c2f8eadf1d891c6cedR67-R108)
* [`any_gold/image/kpi.py`](diffhunk://#diff-81d0175d0e6fd802fd3337b8e3fbe4247648898c574a496f64e89fc4ae0607bbL103-R103): Simplified directory traversal in `_setup` by removing split-specific entity handling.

### Improvements to Dataset Initialization:
* [`any_gold/image/mvtec_ad.py`](diffhunk://#diff-ed17a09f8f52806b251bf8c7434346942c5bde778a6b4b8037747d20241b7c61L74): Removed redundant `root` parameter in `HuggingFaceDataset` initialization, relying on internal path resolution.
* [`any_gold/utils/hugging_face.py`](diffhunk://#diff-a1622c245a419ad674c35b8108dcf4925379c0fa81e8e8be924036575fe43668L35-R40): Updated `HuggingFaceDataset` to use `huggingface_hub.constants.HUGGINGFACE_HUB_CACHE` for the root directory, ensuring consistency with Hugging Face's caching mechanism.

### Enhancements to Directory Management:
* [`any_gold/image/deepglobe.py`](diffhunk://#diff-ad50d1afc78121fab535b04916d69f1003483cd5d28766c2f8eadf1d891c6cedR67-R108): Refactored `_move_data_to_root` to handle split-specific directories and added checks for source directory existence.
* [`any_gold/utils/kaggle.py`](diffhunk://#diff-cca72d029951ecb17bff2d284e938436117ecba61041831e704a0dff286322c3L43-L59): Updated `_move_data_to_root` method signature and removed redundant directory creation logic in `download`.

These changes collectively improve modularity, reduce code duplication, and align dataset handling with external library standards.


## Checklist

no dataset added

- [ ] Does your new dataset inherit from `AnyDataset`?
- [ ] Does your new dataset existence online have been tested? (please add a specific unit test for it)
- [ ] Does the loading of your new dataset work as expected? (please add a specific unit test protected by `TEST_DATASET_LOADING` for it)
- [ ] Has your new dataset added to the README.md file?
