### PR TITLE
only push when you push on main

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,6 +2,8 @@ name: Publish Python distribution to PyPI
 
 on:
   push:
+    branches:
+      - main  # only run on pushes to the main branch
     tags:
       - 'v*'  # only run on version tags, e.g., v1.0.0
 

--- a/.github/workflows/test_release.yaml
+++ b/.github/workflows/test_release.yaml
@@ -1,6 +1,9 @@
 name: Publish Python distribution to TestPyPI
 
-on: push
+on:
+  push:
+    branches:
+      - main  # only run on pushes to the main branch
 
 jobs:
   build:


### PR DESCRIPTION
## Description

This pull request updates GitHub Actions workflows to refine the conditions under which they are triggered. The changes ensure that the workflows only run on pushes to the `main` branch or specific version tags.

### Workflow trigger refinements:
* [`.github/workflows/release.yaml`](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaR5-R6): Updated the `push` event to specify that the workflow should only run on pushes to the `main` branch and version tags matching the pattern `v*` (e.g., `v1.0.0`).
* [`.github/workflows/test_release.yaml`](diffhunk://#diff-472dc4de1d35674a4624ead08c099acd7957f3fc26014e04863390be9e88c273L3-R6): Modified the `push` event to restrict the workflow to only run on pushes to the `main` branch.

## Checklist
not add any dataset
- [ ] Does your new dataset inherit from `AnyDataset`?
- [ ] Does your new dataset existence online have been tested? (please add a specific unit test for it)
- [ ] Does the loading of your new dataset work as expected? (please add a specific unit test protected by `TEST_DATASET_LOADING` for it)
- [ ] Has your new dataset added to the README.md file?
