### PR TITLE
fix release information in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,4 +94,5 @@ To release a new version of the `any-gold` package:
 1. Create a new branch for the release: `git checkout -b release-vX.Y.Z`
 2. Update the version `vX.Y.Z` in `pyproject.toml`
 3. Commit the changes with a message like `release vX.Y.Z`
-4. Add the tag `vX.Y.Z` and push the changes to the main branch
+4. Merge the branch into `main`
+5. trigger a new release on GitHub with the tag `vX.Y.Z`


### PR DESCRIPTION
## Description

This pull request updates the release process documentation for the `any-gold` package in the `README.md` file. The most notable change is the modification of the steps required to release a new version.

### Updates to the release process:

* Step 4 now specifies merging the release branch into `main` instead of adding the tag directly. (`[README.mdL97-R98](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L97-R98)`)
* A new step (Step 5) has been added to trigger a new release on GitHub with the tag `vX.Y.Z`. (`[README.mdL97-R98](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L97-R98)`)

## Checklist
do not add new dataset
- [ ] Does your new dataset inherit from `AnyDataset`?
- [ ] Does your new dataset existence online have been tested? (please add a specific unit test for it)
- [ ] Does the loading of your new dataset work as expected? (please add a specific unit test protected by `TEST_DATASET_LOADING` for it)
- [ ] Has your new dataset added to the README.md file?
