### PR TITLE
Remove get_image_path and fix some inconsistencies

### DIFF
--- a/any_gold/image/deepglobe.py
+++ b/any_gold/image/deepglobe.py
@@ -110,10 +110,6 @@ class DeepGlobeRoadExtraction(AnyVisionSegmentationDataset, KaggleDataset):
     def __len__(self) -> int:
         return len(self.samples)
 
-    def get_image_path(self, index: int) -> Path:
-        """Get the path of an image."""
-        return self.samples[index]
-
     def get_raw(self, index: int) -> DeepGlobeRoadExtractionOutput:
         """Get an image and its corresponding mask together with the index.
 

--- a/any_gold/image/kpi.py
+++ b/any_gold/image/kpi.py
@@ -108,10 +108,6 @@ class KPITask1PatchLevel(AnyVisionSegmentationDataset, SynapseZipBase):
     def __len__(self) -> int:
         return len(self.samples)
 
-    def get_image_path(self, index: int) -> Path:
-        """Get the path of an image."""
-        return self.samples[index][0]
-
     def get_raw(self, index: int) -> KPITask1PatchLevelOutput:
         image_path, disease = self.samples[index]
         mask_path = image_path.parent.parent / f"mask/{image_path.stem[:-3]}mask.jpg"

--- a/any_gold/image/mvtec_ad.py
+++ b/any_gold/image/mvtec_ad.py
@@ -35,13 +35,13 @@ class MVTecADDataset(AnyVisionSegmentationDataset, HuggingFaceDataset):
     The dataset is downloaded from [Hugging Face](https://huggingface.co/datasets/TheoM55/mvtec_all_objects_split)
     and its data will be downloaded and stored in the specified root directory.
 
-    For each category, there are two splits available: train and test.
+    For each category, there are two splits available: `train` and test.
 
     Args:
         root: The root directory where the dataset is stored.
         category: The category of the dataset (e.g., 'bottle', 'cable', 'capsule').
         split: The dataset split to use ('train' or 'test').
-        path: The path of the dataset on Hugging Face.
+        path: The path of the dataset on Hugging Face (same as _HUGGINGFACE_NAME).
         hf_split: it will be category.split.
         transform: A transform to apply to the images.
         target_transform: A transform to apply to the masks.

--- a/any_gold/image/plantseg.py
+++ b/any_gold/image/plantseg.py
@@ -130,10 +130,6 @@ class PlantSeg(AnyVisionSegmentationDataset, ZenodoZipBase):
     def __len__(self) -> int:
         return len(self.samples)
 
-    def get_image_path(self, index: int) -> Path:
-        """Get the path of an image."""
-        return self.samples[index][0]
-
     def get_raw(self, index: int) -> PlantSegOutput:
         """Get the image and its corresponding mask together with the plant species, disease and index."""
         image_path, plant, disease = self.samples[index]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.12' and sys_platform == 'darwin'",
@@ -141,7 +141,7 @@ wheels = [
 
 [[package]]
 name = "any-gold"
-version = "0.1.0"
+version = "0.1.1"
 source = { virtual = "." }
 dependencies = [
     { name = "datasets" },


### PR DESCRIPTION
## Description

This pull request primarily removes the unused or redundant get_image_path methods from several dataset classes in the codebase, simplifying the dataset interfaces. Additionally, there are minor improvements to the documentation in the MVTecAD dataset class.

Dataset interface simplification:

* Removed the get_image_path method from the `DeepGlobeRoadExtractionDataset`, `KPITask1PatchLevelDataset`, and `PlantSegDataset` classes as it was unused and redundant. [[1]](diffhunk://#diff-ad50d1afc78121fab535b04916d69f1003483cd5d28766c2f8eadf1d891c6cedL113-L116) [[2]](diffhunk://#diff-81d0175d0e6fd802fd3337b8e3fbe4247648898c574a496f64e89fc4ae0607bbL111-L114) [[3]](diffhunk://#diff-6212d1bcd64724260bb69372ad84e2e8b64877440d5263bdfd13333f3eea327cL133-L136)

Documentation improvements:

* Updated the docstring for the `MVTecADDataset` class to clarify the meaning of the `path` argument and the naming of the `train` split.

## Checklist

no dataset added

- [ ] Does your new dataset inherit from `AnyDataset`?
- [ ] Does your new dataset existence online have been tested? (please add a specific unit test for it)
- [ ] Does the loading of your new dataset work as expected? (please add a specific unit test protected by `TEST_DATASET_LOADING` for it)
- [ ] Has your new dataset added to the README.md file?
