### PR TITLE
run test pypi only on release branch

### DIFF
--- a/.github/workflows/test_release.yaml
+++ b/.github/workflows/test_release.yaml
@@ -1,9 +1,9 @@
 name: Publish Python distribution to TestPyPI
 
 on:
-  push:
+  pull_request:
     branches:
-      - main  # only run on pushes to the main branch
+      - release-v**  # only run on PRs targeting the main branch
 
 jobs:
   build:


### PR DESCRIPTION
## Description

This pull request updates the GitHub Actions workflow for testing the Python distributions publication, changing when the workflow is triggered. Instead of running on every push to the main branch, it now runs on pull requests targeting branches that match the `release-v**` pattern.

Workflow trigger update:

* [`.github/workflows/test_release.yaml`](diffhunk://#diff-472dc4de1d35674a4624ead08c099acd7957f3fc26014e04863390be9e88c273L4-R6): Changed the workflow trigger from `push` events on the `main` branch to `pull_request` events targeting `release-v**` branches.

## Checklist

no dataset added.

- [ ] Does your new dataset inherit from `AnyDataset`?
- [ ] Does your new dataset existence online have been tested? (please add a specific unit test for it)
- [ ] Does the loading of your new dataset work as expected? (please add a specific unit test protected by `TEST_DATASET_LOADING` for it)
- [ ] Has your new dataset added to the README.md file?
